### PR TITLE
feat: Sanctumトークン認証とAPIエンドポイントを追加

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'     => 'required|string|max:255',
+            'email'    => 'required|email|unique:users,email',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        $user  = User::create([
+            'name'     => $validated['name'],
+            'email'    => $validated['email'],
+            'password' => Hash::make($validated['password']),
+        ]);
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        return response()->json(['token' => $token], 201);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email'    => 'required|email',
+            'password' => 'required|string',
+        ]);
+
+        $user = User::where('email', $validated['email'])->first();
+
+        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => ['メールアドレスまたはパスワードが正しくありません。'],
+            ]);
+        }
+
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        return response()->json(['token' => $token]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Controllers/Api/DailyExpenditureController.php
+++ b/backend/app/Http/Controllers/Api/DailyExpenditureController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DailyExpenditure;
+use App\Services\DailyExpenditureService;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DailyExpenditureController extends Controller
+{
+    public function __construct(private readonly DailyExpenditureService $service) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json($this->service->getAllUserDailyExpenditure($request->user()->id));
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'expense_name' => 'required|string|max:255',
+            'expense_at'   => 'required|date',
+        ]);
+
+        $result = $this->service->createDailyExpenditure(
+            $request->user()->id,
+            $validated['expense_name'],
+            Carbon::parse($validated['expense_at']),
+        );
+
+        return response()->json($result, 201);
+    }
+
+    public function destroy(DailyExpenditure $dailyExpenditure): JsonResponse
+    {
+        $this->service->deleteDailyExpenditure($dailyExpenditure->id);
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Controllers/Api/DailyExpenditureDailyExpenditureTagRelationController.php
+++ b/backend/app/Http/Controllers/Api/DailyExpenditureDailyExpenditureTagRelationController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DailyExpenditureDailyExpenditureTagRelation;
+use App\Services\DailyExpenditureDailyExpenditureTagRelationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DailyExpenditureDailyExpenditureTagRelationController extends Controller
+{
+    public function __construct(
+        private readonly DailyExpenditureDailyExpenditureTagRelationService $service
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json(
+            $this->service->getAllUserDailyExpenditureDailyExpenditureTagRelation($request->user()->id)
+        );
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'daily_expenditure_id'     => 'required|integer|exists:daily_expenditures,id',
+            'daily_expenditure_tag_id' => 'required|integer|exists:daily_expenditure_tags,id',
+        ]);
+
+        $result = $this->service->createDailyExpenditureDailyExpenditureTagRelation(
+            $request->user()->id,
+            $validated['daily_expenditure_tag_id'],
+            $validated['daily_expenditure_id'],
+        );
+
+        return response()->json($result, 201);
+    }
+
+    public function destroy(DailyExpenditureDailyExpenditureTagRelation $dailyExpenditureDailyExpenditureTagRelation): JsonResponse
+    {
+        $this->service->deleteDailyExpenditureDailyExpenditureTagRelation(
+            $dailyExpenditureDailyExpenditureTagRelation->id
+        );
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Controllers/Api/DailyExpenditureMustExpenditureTagRelationController.php
+++ b/backend/app/Http/Controllers/Api/DailyExpenditureMustExpenditureTagRelationController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DailyExpenditureMustExpenditureTagRelation;
+use App\Services\DailyExpenditureMustExpenditureTagRelationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DailyExpenditureMustExpenditureTagRelationController extends Controller
+{
+    public function __construct(
+        private readonly DailyExpenditureMustExpenditureTagRelationService $service
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json(
+            $this->service->getAllUserDailyExpenditureMustExpenditureTagRelation($request->user()->id)
+        );
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'daily_expenditure_id'    => 'required|integer|exists:daily_expenditures,id',
+            'must_expenditure_tag_id' => 'required|integer|exists:must_expenditure_tags,id',
+        ]);
+
+        $result = $this->service->createDailyExpenditureMustExpenditureTagRelation(
+            $request->user()->id,
+            $validated['must_expenditure_tag_id'],
+            $validated['daily_expenditure_id'],
+        );
+
+        return response()->json($result, 201);
+    }
+
+    public function destroy(DailyExpenditureMustExpenditureTagRelation $dailyExpenditureMustExpenditureTagRelation): JsonResponse
+    {
+        $this->service->deleteDailyExpenditureMustExpenditureTagRelation(
+            $dailyExpenditureMustExpenditureTagRelation->id
+        );
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Controllers/Api/DailyExpenditureTagController.php
+++ b/backend/app/Http/Controllers/Api/DailyExpenditureTagController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DailyExpenditureTag;
+use App\Services\DailyExpenditureTagService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DailyExpenditureTagController extends Controller
+{
+    public function __construct(private readonly DailyExpenditureTagService $service) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json($this->service->getAllUserDailyExpenditureTag($request->user()->id));
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'tag_name' => 'required|string|max:255',
+        ]);
+
+        $result = $this->service->createDailyExpenditureTag(
+            $request->user()->id,
+            $validated['tag_name'],
+        );
+
+        return response()->json($result, 201);
+    }
+
+    public function destroy(DailyExpenditureTag $dailyExpenditureTag): JsonResponse
+    {
+        $this->service->deleteDailyExpenditureTag($dailyExpenditureTag->id);
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Controllers/Api/MustExpenditureController.php
+++ b/backend/app/Http/Controllers/Api/MustExpenditureController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\MustExpenditure;
+use App\Services\MustExpenditureService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MustExpenditureController extends Controller
+{
+    public function __construct(private readonly MustExpenditureService $service) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json($this->service->getAllUserMustExpenditure($request->user()->id));
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'expense_name' => 'required|string|max:255',
+        ]);
+
+        $result = $this->service->createMustExpenditure(
+            $request->user()->id,
+            $validated['expense_name'],
+        );
+
+        return response()->json($result, 201);
+    }
+
+    public function destroy(MustExpenditure $mustExpenditure): JsonResponse
+    {
+        $this->service->deleteMustExpenditure($mustExpenditure->id);
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Controllers/Api/MustExpenditureMustExpenditureTagRelationController.php
+++ b/backend/app/Http/Controllers/Api/MustExpenditureMustExpenditureTagRelationController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\MustExpenditureMustExpenditureTagRelation;
+use App\Services\MustExpenditureMustExpenditureTagRelationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MustExpenditureMustExpenditureTagRelationController extends Controller
+{
+    public function __construct(
+        private readonly MustExpenditureMustExpenditureTagRelationService $service
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json(
+            $this->service->getAllUserMustExpenditureMustExpenditureTagRelation($request->user()->id)
+        );
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'must_expenditure_id'     => 'required|integer|exists:must_expenditures,id',
+            'must_expenditure_tag_id' => 'required|integer|exists:must_expenditure_tags,id',
+        ]);
+
+        $result = $this->service->createMustExpenditureMustExpenditureTagRelation(
+            $request->user()->id,
+            $validated['must_expenditure_tag_id'],
+            $validated['must_expenditure_id'],
+        );
+
+        return response()->json($result, 201);
+    }
+
+    public function destroy(MustExpenditureMustExpenditureTagRelation $mustExpenditureMustExpenditureTagRelation): JsonResponse
+    {
+        $this->service->deleteMustExpenditureMustExpenditureTagRelation(
+            $mustExpenditureMustExpenditureTagRelation->id
+        );
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Controllers/Api/MustExpenditureTagController.php
+++ b/backend/app/Http/Controllers/Api/MustExpenditureTagController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\MustExpenditureTag;
+use App\Services\MustExpenditureTagService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MustExpenditureTagController extends Controller
+{
+    public function __construct(private readonly MustExpenditureTagService $service) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json($this->service->getAllUserMustExpenditureTag($request->user()->id));
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'tag_name' => 'required|string|max:255',
+        ]);
+
+        $result = $this->service->createMustExpenditureTag(
+            $request->user()->id,
+            $validated['tag_name'],
+        );
+
+        return response()->json($result, 201);
+    }
+
+    public function destroy(MustExpenditureTag $mustExpenditureTag): JsonResponse
+    {
+        $this->service->deleteMustExpenditureTag($mustExpenditureTag->id);
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -7,11 +7,12 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.3",
         "laravel/tinker": "^2.10.1"
     },
     "require-dev": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53b5d56b3b7e3cbac1713e68c8850f6c",
+    "content-hash": "f4dbe09ac5bbddf1a0ad59af35d90a39",
     "packages": [
         {
             "name": "brick/math",
@@ -1333,6 +1333,69 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.16"
             },
             "time": "2026-03-23T14:35:33+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "e3b85d6e36ad00e5db2d1dcc27c81ffdf15cbf76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/e3b85d6e36ad00e5db2d1dcc27c81ffdf15cbf76",
+                "reference": "e3b85d6e36ad00e5db2d1dcc27c81ffdf15cbf76",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-02-07T17:19:31+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -1,0 +1,84 @@
+<?php
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+    ],
+
+];

--- a/backend/database/migrations/2026_04_04_000005_create_must_expenditure_must_expenditure_tag_relation_table.php
+++ b/backend/database/migrations/2026_04_04_000005_create_must_expenditure_must_expenditure_tag_relation_table.php
@@ -11,8 +11,14 @@ return new class extends Migration
         Schema::create('must_expenditure_must_expenditure_tag_relations', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete()->comment('必須出資に関わるタグを登録したユーザーのID');
-            $table->foreignId('must_expenditure_id')->constrained()->cascadeOnDelete()->comment('必須出資ID');
-            $table->foreignId('must_expenditure_tag_id')->constrained()->cascadeOnDelete()->comment('必須出資タグID');
+            $table->foreignId('must_expenditure_id')
+                ->constrained('must_expenditures', 'id', 'fk_me_met_me')
+                ->cascadeOnDelete()
+                ->comment('必須出資ID');
+            $table->foreignId('must_expenditure_tag_id')
+                ->constrained('must_expenditure_tags', 'id', 'fk_me_met_met')
+                ->cascadeOnDelete()
+                ->comment('必須出資タグID');
             $table->timestamps();
 
             $table->index(

--- a/backend/database/migrations/2026_04_04_000006_create_daily_expenditure_must_expenditure_tag_relation_table.php
+++ b/backend/database/migrations/2026_04_04_000006_create_daily_expenditure_must_expenditure_tag_relation_table.php
@@ -11,8 +11,14 @@ return new class extends Migration
         Schema::create('daily_expenditure_must_expenditure_tag_relations', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete()->comment('必須出資に関わるタグを登録したユーザーのID');
-            $table->foreignId('daily_expenditure_id')->constrained()->cascadeOnDelete()->comment('出資ID');
-            $table->foreignId('must_expenditure_tag_id')->constrained()->cascadeOnDelete()->comment('必須出資タグID');
+            $table->foreignId('daily_expenditure_id')
+                ->constrained('daily_expenditures', 'id', 'fk_de_met_de')
+                ->cascadeOnDelete()
+                ->comment('出資ID');
+            $table->foreignId('must_expenditure_tag_id')
+                ->constrained('must_expenditure_tags', 'id', 'fk_de_met_met')
+                ->cascadeOnDelete()
+                ->comment('必須出資タグID');
             $table->timestamps();
 
             $table->index(

--- a/backend/database/migrations/2026_04_04_000007_create_daily_expenditure_daily_expenditure_tag_relation_table.php
+++ b/backend/database/migrations/2026_04_04_000007_create_daily_expenditure_daily_expenditure_tag_relation_table.php
@@ -10,9 +10,15 @@ return new class extends Migration
     {
         Schema::create('daily_expenditure_daily_expenditure_tag_relations', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete()->comment('必須出資に関わるタグを登録したユーザーのID');
-            $table->foreignId('daily_expenditure_id')->constrained()->cascadeOnDelete()->comment('出資ID');
-            $table->foreignId('daily_expenditure_tag_id')->constrained()->cascadeOnDelete()->comment('出資タグID');
+            $table->foreignId('user_id')->constrained('users', 'id', 'fk_de_det_user')->cascadeOnDelete()->comment('必須出資に関わるタグを登録したユーザーのID');
+            $table->foreignId('daily_expenditure_id')
+                ->constrained('daily_expenditures', 'id', 'fk_de_det_de')
+                ->cascadeOnDelete()
+                ->comment('出資ID');
+            $table->foreignId('daily_expenditure_tag_id')
+                ->constrained('daily_expenditure_tags', 'id', 'fk_de_det_det')
+                ->cascadeOnDelete()
+                ->comment('出資タグID');
             $table->timestamps();
 
             $table->index(

--- a/backend/database/migrations/2026_04_04_174609_create_personal_access_tokens_table.php
+++ b/backend/database/migrations/2026_04_04_174609_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,10 +1,52 @@
 <?php
 
+use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\DailyExpenditureController;
+use App\Http\Controllers\Api\DailyExpenditureDailyExpenditureTagRelationController;
+use App\Http\Controllers\Api\DailyExpenditureMustExpenditureTagRelationController;
+use App\Http\Controllers\Api\DailyExpenditureTagController;
+use App\Http\Controllers\Api\MustExpenditureController;
+use App\Http\Controllers\Api\MustExpenditureMustExpenditureTagRelationController;
+use App\Http\Controllers\Api\MustExpenditureTagController;
 use App\Http\Controllers\Api\SummaryController;
 use App\Http\Controllers\Api\TransactionController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json(['status' => 'ok']));
 
-Route::apiResource('transactions', TransactionController::class);
-Route::get('summary', [SummaryController::class, 'index']);
+Route::post('/auth/register', [AuthController::class, 'register']);
+Route::post('/auth/login',    [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/auth/logout', [AuthController::class, 'logout']);
+
+    Route::apiResource('transactions', TransactionController::class);
+    Route::get('summary', [SummaryController::class, 'index']);
+
+    Route::apiResource('daily-expenditures', DailyExpenditureController::class)
+        ->only(['index', 'store', 'destroy']);
+
+    Route::apiResource('daily-expenditure-tags', DailyExpenditureTagController::class)
+        ->only(['index', 'store', 'destroy']);
+
+    Route::apiResource('must-expenditures', MustExpenditureController::class)
+        ->only(['index', 'store', 'destroy']);
+
+    Route::apiResource('must-expenditure-tags', MustExpenditureTagController::class)
+        ->only(['index', 'store', 'destroy']);
+
+    Route::apiResource(
+        'daily-expenditure-daily-expenditure-tag-relations',
+        DailyExpenditureDailyExpenditureTagRelationController::class
+    )->only(['index', 'store', 'destroy']);
+
+    Route::apiResource(
+        'daily-expenditure-must-expenditure-tag-relations',
+        DailyExpenditureMustExpenditureTagRelationController::class
+    )->only(['index', 'store', 'destroy']);
+
+    Route::apiResource(
+        'must-expenditure-must-expenditure-tag-relations',
+        MustExpenditureMustExpenditureTagRelationController::class
+    )->only(['index', 'store', 'destroy']);
+});


### PR DESCRIPTION
- laravel/sanctumをインストールしUserモデルにHasApiTokensを追加
- 認証API (register/login/logout) を追加
- DailyExpenditure, DailyExpenditureTag, MustExpenditure, MustExpenditureTag の各CRUDコントローラーを追加 (index/store/destroyのみ)
- 3つのリレーションテーブルのAPIコントローラーを追加
- 全APIをauth:sanctumミドルウェアで保護
- リレーション系マイグレーションの外部キー制約名をMySQL64文字制限に合わせて短縮