### PR TITLE
feat: SPA認証（HttpOnly Cookie）を実装

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 
@@ -19,14 +20,16 @@ class AuthController extends Controller
             'password' => 'required|string|min:8|confirmed',
         ]);
 
-        $user  = User::create([
+        $user = User::create([
             'name'     => $validated['name'],
             'email'    => $validated['email'],
             'password' => Hash::make($validated['password']),
         ]);
-        $token = $user->createToken('auth_token')->plainTextToken;
 
-        return response()->json(['token' => $token], 201);
+        Auth::login($user);
+        $request->session()->regenerate();
+
+        return response()->json(['user' => $user], 201);
     }
 
     public function login(Request $request): JsonResponse
@@ -36,23 +39,28 @@ class AuthController extends Controller
             'password' => 'required|string',
         ]);
 
-        $user = User::where('email', $validated['email'])->first();
-
-        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+        if (! Auth::attempt($validated)) {
             throw ValidationException::withMessages([
                 'email' => ['メールアドレスまたはパスワードが正しくありません。'],
             ]);
         }
 
-        $token = $user->createToken('auth_token')->plainTextToken;
+        $request->session()->regenerate();
 
-        return response()->json(['token' => $token]);
+        return response()->json(['user' => Auth::user()]);
     }
 
     public function logout(Request $request): JsonResponse
     {
-        $request->user()->currentAccessToken()->delete();
+        Auth::guard('web')->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
 
         return response()->json(null, 204);
+    }
+
+    public function me(Request $request): JsonResponse
+    {
+        return response()->json(['user' => $request->user()]);
     }
 }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -12,7 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->statefulApi();
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -18,7 +18,8 @@ Route::post('/auth/register', [AuthController::class, 'register']);
 Route::post('/auth/login',    [AuthController::class, 'login']);
 
 Route::middleware('auth:sanctum')->group(function () {
-    Route::post('/auth/logout', [AuthController::class, 'logout']);
+    Route::get('/auth/me',       [AuthController::class, 'me']);
+    Route::post('/auth/logout',  [AuthController::class, 'logout']);
 
     Route::apiResource('transactions', TransactionController::class);
     Route::get('summary', [SummaryController::class, 'index']);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,26 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { AuthProvider } from './contexts/AuthContext'
 import Layout from './components/Layout'
+import PrivateRoute from './components/PrivateRoute'
 import Dashboard from './pages/Dashboard'
 import Transactions from './pages/Transactions'
+import Login from './pages/Login'
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="transactions" element={<Transactions />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route element={<PrivateRoute />}>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<Dashboard />} />
+              <Route path="transactions" element={<Transactions />} />
+            </Route>
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   )
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,12 +1,21 @@
-import { Outlet, NavLink } from 'react-router-dom'
+import { Outlet, NavLink, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 
 export default function Layout() {
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogout = async () => {
+    await logout()
+    navigate('/login', { replace: true })
+  }
+
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white shadow-sm">
         <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
           <h1 className="text-xl font-bold text-indigo-600">NostaleEdger</h1>
-          <nav className="flex gap-4">
+          <nav className="flex gap-4 items-center">
             <NavLink
               to="/"
               end
@@ -28,6 +37,13 @@ export default function Layout() {
             >
               取引一覧
             </NavLink>
+            <span className="text-sm text-gray-500">{user?.name}</span>
+            <button
+              onClick={handleLogout}
+              className="text-sm text-gray-500 hover:text-red-500"
+            >
+              ログアウト
+            </button>
           </nav>
         </div>
       </header>

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,0 +1,12 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+export default function PrivateRoute() {
+  const { user, loading } = useAuth()
+
+  if (loading) {
+    return <p className="text-center text-gray-400 py-12">読み込み中...</p>
+  }
+
+  return user ? <Outlet /> : <Navigate to="/login" replace />
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,69 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import axios from 'axios'
+
+const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+axios.defaults.withCredentials = true
+
+interface User {
+  id: number
+  name: string
+  email: string
+}
+
+interface AuthContextType {
+  user: User | null
+  loading: boolean
+  login: (email: string, password: string) => Promise<void>
+  register: (name: string, email: string, password: string, passwordConfirmation: string) => Promise<void>
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextType | null>(null)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    axios
+      .get<{ user: User }>(`${API_URL}/auth/me`)
+      .then((res) => setUser(res.data.user))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const login = async (email: string, password: string) => {
+    await axios.get('/sanctum/csrf-cookie')
+    const res = await axios.post<{ user: User }>(`${API_URL}/auth/login`, { email, password })
+    setUser(res.data.user)
+  }
+
+  const register = async (name: string, email: string, password: string, passwordConfirmation: string) => {
+    await axios.get('/sanctum/csrf-cookie')
+    const res = await axios.post<{ user: User }>(`${API_URL}/auth/register`, {
+      name,
+      email,
+      password,
+      password_confirmation: passwordConfirmation,
+    })
+    setUser(res.data.user)
+  }
+
+  const logout = async () => {
+    await axios.post(`${API_URL}/auth/logout`)
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+export default function Login() {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await login(email, password)
+      navigate('/', { replace: true })
+    } catch {
+      setError('メールアドレスまたはパスワードが正しくありません。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="bg-white rounded-xl shadow p-8 w-full max-w-sm">
+        <h1 className="text-2xl font-bold text-indigo-600 mb-6 text-center">NostaleEdger</h1>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="block text-sm text-gray-600 mb-1">メールアドレス</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-600 mb-1">パスワード</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="bg-indigo-600 text-white rounded-lg py-2 text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {loading ? 'ログイン中...' : 'ログイン'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- bootstrap/app.phpにstatefulApi()を追加
- .envにSESSION_DOMAIN設定を追加
- AuthControllerをセッションベース認証に変更（register/login/logout/me）
- routes/api.phpにGET /auth/meを追加
- AuthContext（ログイン状態管理）を追加
- PrivateRoute（未認証リダイレクト）を追加
- Loginページを追加
- App.tsxにAuthProviderとPrivateRouteを組み込み
- LayoutにログアウトボタンとユーザeName表示を追加