### PR TITLE
#no | アカウント登録画面の追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import PrivateRoute from './components/PrivateRoute'
 import Dashboard from './pages/Dashboard'
 import Transactions from './pages/Transactions'
 import Login from './pages/Login'
+import RegistAccount from './pages/regist/RegistAccount'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<Login />} />
+          <Route path="/registAccount" element={<RegistAccount />} />
           <Route element={<PrivateRoute />}>
             <Route path="/" element={<Layout />}>
               <Route index element={<Dashboard />} />

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { Link } from 'react-router-dom'
 
 export default function Login() {
   const { login } = useAuth()
@@ -59,6 +60,12 @@ export default function Login() {
             {loading ? 'ログイン中...' : 'ログイン'}
           </button>
         </form>
+        <p className="text-center text-sm text-gray-500 mt-4">
+          アカウントをお持ちでない方は
+          <Link to="/registAccount" className="text-indigo-600 hover:underline ml-1">
+            こちら
+          </Link>
+        </p>
       </div>
     </div>
   )

--- a/frontend/src/pages/regist/RegistAccount.tsx
+++ b/frontend/src/pages/regist/RegistAccount.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
+import { Link } from 'react-router-dom'
 
 export default function RegistAccount() {
   const { register } = useAuth()
@@ -12,6 +13,7 @@ export default function RegistAccount() {
   const [passwordConfirmation, setPasswordConfirmation] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -19,7 +21,8 @@ export default function RegistAccount() {
     setLoading(true)
     try {
       await register(name, email, password, passwordConfirmation)
-      navigate('/', { replace: true })
+      setSuccess(true)
+      setTimeout(() => navigate('/login', { replace: true }), 2000)
     } catch {
       setError('登録に失敗しました。入力内容を確認してください。')
     } finally {

--- a/frontend/src/pages/regist/RegistAccount.tsx
+++ b/frontend/src/pages/regist/RegistAccount.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../../contexts/AuthContext'
+
+export default function RegistAccount() {
+  const { register } = useAuth()
+  const navigate = useNavigate()
+
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [passwordConfirmation, setPasswordConfirmation] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await register(name, email, password, passwordConfirmation)
+      navigate('/', { replace: true })
+    } catch {
+      setError('登録に失敗しました。入力内容を確認してください。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="bg-white rounded-xl shadow p-8 w-full max-w-sm">
+        <h1 className="text-2xl font-bold text-indigo-600 mb-6 text-center">NostaleEdger</h1>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="block text-sm text-gray-600 mb-1">名前</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-600 mb-1">メールアドレス</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-600 mb-1">パスワード</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-600 mb-1">パスワード（確認）</label>
+            <input
+              type="password"
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="bg-indigo-600 text-white rounded-lg py-2 text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {loading ? '登録中...' : 'アカウント作成'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/regist/RegistAccount.tsx
+++ b/frontend/src/pages/regist/RegistAccount.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
-import { Link } from 'react-router-dom'
 
 export default function RegistAccount() {
   const { register } = useAuth()

--- a/frontend/src/pages/regist/RegistAccount.tsx
+++ b/frontend/src/pages/regist/RegistAccount.tsx
@@ -75,6 +75,7 @@ export default function RegistAccount() {
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
             />
           </div>
+          {success && <p className="text-green-600 text-sm">アカウントの登録が完了しました。ログイン画面に移動します...</p>}
           {error && <p className="text-red-500 text-sm">{error}</p>}
           <button
             type="submit"


### PR DESCRIPTION
# 行ったこと
アカウント登録動線を作成、および実際の画面を作成しました
またログイン画面からの動線、およびアカウント登録後に行われる画面遷移周りも整えました

# ロジック
アカウント登録時はlogin画面に遷移するように、またログインする際にアカウントがなければ特定のボタンを押下することでアカウントの登録を行える動線を追加しました
実際の画面は下になります

<img width="378" height="350" alt="スクリーンショット 2026-04-11 19 20 33" src="https://github.com/user-attachments/assets/29c5902f-7a84-401b-a7bf-ca5cb246595f" />

# 実際のアカウント登録画面
<img width="389" height="473" alt="スクリーンショット 2026-04-11 19 20 28" src="https://github.com/user-attachments/assets/df77e6f0-1196-4722-b339-eb40d3dcc30b" />
