### PR TITLE
#26 | ヘッダーの追加

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import MainPageHeader from './header/MainPagaHeader'
 
 export default function Layout() {
   const { user, logout } = useAuth()
@@ -13,39 +14,9 @@ export default function Layout() {
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white shadow-sm">
-        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
-          <h1 className="text-xl font-bold text-indigo-600">NostaleEdger</h1>
-          <nav className="flex gap-4 items-center">
-            <NavLink
-              to="/"
-              end
-              className={({ isActive }) =>
-                isActive
-                  ? 'text-indigo-600 font-semibold'
-                  : 'text-gray-600 hover:text-indigo-500'
-              }
-            >
-              ダッシュボード
-            </NavLink>
-            <NavLink
-              to="/transactions"
-              className={({ isActive }) =>
-                isActive
-                  ? 'text-indigo-600 font-semibold'
-                  : 'text-gray-600 hover:text-indigo-500'
-              }
-            >
-              取引一覧
-            </NavLink>
-            <span className="text-sm text-gray-500">{user?.name}</span>
-            <button
-              onClick={handleLogout}
-              className="text-sm text-gray-500 hover:text-red-500"
-            >
-              ログアウト
-            </button>
-          </nav>
-        </div>
+          <div className='max-w-5xl mx-auto px-4 py-4 flex w-full'>
+            <MainPageHeader/>
+          </div>
       </header>
       <main className="max-w-5xl mx-auto px-4 py-8">
         <Outlet />

--- a/frontend/src/components/header/AppName.tsx
+++ b/frontend/src/components/header/AppName.tsx
@@ -1,0 +1,7 @@
+export default function AppName() {
+    return (
+        <div>
+            NostaleEdger
+        </div>
+    )
+}

--- a/frontend/src/components/header/HeaderTag.tsx
+++ b/frontend/src/components/header/HeaderTag.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom'
+
+interface Props {
+    headerMessage: string,
+    to: string
+}  
+
+export default function HeaderTag({
+    headerMessage,
+    to,
+} : Props) {
+    return (
+        <div className='flex-none w-18 ml-auto mr-auto'>
+            <Link to={to} className="text-indigo-600 hover:underline">
+                {headerMessage}
+            </Link>
+        </div>
+    )
+}

--- a/frontend/src/components/header/MainPagaHeader.tsx
+++ b/frontend/src/components/header/MainPagaHeader.tsx
@@ -1,0 +1,30 @@
+import HeaderTag from './HeaderTag'
+import AppName from './AppName'
+
+export default function AllPageHeader() {
+    return (
+        <div className="flex items-center w-full">
+            <div className="flex gap-4 flex-wrap">
+                <HeaderTag
+                    headerMessage = '確定支出追加・削除'
+                    to = "/login"
+                />
+                <HeaderTag
+                    headerMessage = '支出追加・削除'
+                    to = "/login"
+                />
+                <HeaderTag
+                    headerMessage = 'タグ追加・削除'
+                    to = "/login"
+                />
+                <HeaderTag
+                    headerMessage = '必須出資タグ追加・削除'
+                    to = "/login"
+                />
+            </div>
+            <div className="ml-auto shrink-0 pl-4">
+                <AppName/>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
+import MainPageHeader from '../components/header/MainPagaHeader'
 
 interface Summary {
   income: number


### PR DESCRIPTION
ヘッダーの追加を行いました
縮小、拡大した時にもデザインの崩れが発生しないように対応しています

## 縮小したケース
<img width="799" height="232" alt="スクリーンショット 2026-04-12 16 31 22" src="https://github.com/user-attachments/assets/3e91ac29-bb23-4e68-bcef-266d734bd368" />

## 拡大したケース
<img width="1127" height="109" alt="スクリーンショット 2026-04-12 16 31 28" src="https://github.com/user-attachments/assets/c09adf38-d0c2-49df-8a7b-ad04a378c4a9" />
