### PR TITLE
#26 | アプリヘッダー部分の基礎を作成

### DIFF
--- a/frontend/src/components/contents/allExpenditure.tsx
+++ b/frontend/src/components/contents/allExpenditure.tsx
@@ -12,11 +12,17 @@ const API_URL = import.meta.env.VITE_API_URL ?? '/api'
 export default function AllExpenditure() {
     const [expenditures, setExpenditures] = useState<AmountByTag[]>([])
 
-    useEffect(() => {
+    const fetchData = () => {
         axios.get<AmountByTag[]>(
             `${API_URL}/daily-expenditure-daily-expenditure-tag-relations/amount-by-tag`,
             { withCredentials: true }
         ).then((res) => setExpenditures(res.data))
+    }
+
+    useEffect(() => {
+        fetchData()
+        window.addEventListener('expenditure-registered', fetchData)
+        return () => window.removeEventListener('expenditure-registered', fetchData)
     }, [])
 
     const maxAmount = Math.max(...expenditures.map((item) => item.total_amount), 1)

--- a/frontend/src/components/contents/form/addExpenditureForm.tsx
+++ b/frontend/src/components/contents/form/addExpenditureForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import axios from 'axios'
 
 interface Props {
@@ -6,26 +6,65 @@ interface Props {
     onCancel: () => void
 }
 
+interface Tag {
+    id: number
+    tag_name: string
+}
+
 const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+const config = {
+    'daily-expenditures': {
+        tagEndpoint: 'daily-expenditure-tags',
+        relationEndpoint: 'daily-expenditure-daily-expenditure-tag-relations',
+        expenditureKey: 'daily_expenditure_id',
+        tagKey: 'daily_expenditure_tag_id',
+    },
+    'must-expenditures': {
+        tagEndpoint: 'must-expenditure-tags',
+        relationEndpoint: 'must-expenditure-must-expenditure-tag-relations',
+        expenditureKey: 'must_expenditure_id',
+        tagKey: 'must_expenditure_tag_id',
+    },
+} as const
 
 export default function AddExpenditureForm({ apiEndpoint, onCancel }: Props) {
     const [expenseName, setExpenseName] = useState('')
     const [amount, setAmount] = useState('')
     const [expenseAt, setExpenseAt] = useState('')
+    const [tagId, setTagId] = useState<number | ''>('')
+    const [tags, setTags] = useState<Tag[]>([])
     const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const cfg = config[apiEndpoint as keyof typeof config]
+
+    useEffect(() => {
+        if (!cfg) return
+        axios.get<Tag[]>(`${API_URL}/${cfg.tagEndpoint}`, { withCredentials: true })
+            .then((res) => setTags(res.data))
+    }, [apiEndpoint])
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
         setIsSubmitting(true)
         try {
-            await axios.post(
+            const res = await axios.post(
                 `${API_URL}/${apiEndpoint}`,
                 { expense_name: expenseName, amount: Number(amount), expense_at: expenseAt },
                 { withCredentials: true }
             )
+            if (cfg && tagId !== '') {
+                await axios.post(
+                    `${API_URL}/${cfg.relationEndpoint}`,
+                    { [cfg.expenditureKey]: res.data.id, [cfg.tagKey]: tagId },
+                    { withCredentials: true }
+                )
+            }
             setExpenseName('')
             setAmount('')
             setExpenseAt('')
+            setTagId('')
+            window.dispatchEvent(new CustomEvent('expenditure-registered'))
             onCancel()
         } finally {
             setIsSubmitting(false)
@@ -65,6 +104,21 @@ export default function AddExpenditureForm({ apiEndpoint, onCancel }: Props) {
                     className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
                 />
             </div>
+            {cfg && (
+                <div>
+                    <label className="block text-xs text-gray-500 mb-1">タグ</label>
+                    <select
+                        value={tagId}
+                        onChange={(e) => setTagId(e.target.value === '' ? '' : Number(e.target.value))}
+                        className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                    >
+                        <option value="">タグを選択</option>
+                        {tags.map((tag) => (
+                            <option key={tag.id} value={tag.id}>{tag.tag_name}</option>
+                        ))}
+                    </select>
+                </div>
+            )}
             <div className="flex gap-2 pt-1">
                 <button
                     type="button"

--- a/frontend/src/components/contents/form/addExpenditureForm.tsx
+++ b/frontend/src/components/contents/form/addExpenditureForm.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import axios from 'axios'
+
+interface Props {
+    apiEndpoint: string
+    onCancel: () => void
+}
+
+const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+export default function AddExpenditureForm({ apiEndpoint, onCancel }: Props) {
+    const [expenseName, setExpenseName] = useState('')
+    const [amount, setAmount] = useState('')
+    const [expenseAt, setExpenseAt] = useState('')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setIsSubmitting(true)
+        try {
+            await axios.post(
+                `${API_URL}/${apiEndpoint}`,
+                { expense_name: expenseName, amount: Number(amount), expense_at: expenseAt },
+                { withCredentials: true }
+            )
+            setExpenseName('')
+            setAmount('')
+            setExpenseAt('')
+            onCancel()
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-3 mt-2">
+            <div>
+                <label className="block text-xs text-gray-500 mb-1">支出名</label>
+                <input
+                    type="text"
+                    value={expenseName}
+                    onChange={(e) => setExpenseName(e.target.value)}
+                    required
+                    className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                />
+            </div>
+            <div>
+                <label className="block text-xs text-gray-500 mb-1">金額（円）</label>
+                <input
+                    type="number"
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value)}
+                    required
+                    min={0}
+                    className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                />
+            </div>
+            <div>
+                <label className="block text-xs text-gray-500 mb-1">日付</label>
+                <input
+                    type="date"
+                    value={expenseAt}
+                    onChange={(e) => setExpenseAt(e.target.value)}
+                    required
+                    className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                />
+            </div>
+            <div className="flex gap-2 pt-1">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="flex-1 text-sm text-gray-500 border border-gray-300 rounded py-1 hover:bg-gray-50"
+                >
+                    キャンセル
+                </button>
+                <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="flex-1 text-sm text-white bg-indigo-500 rounded py-1 hover:bg-indigo-600 disabled:opacity-50"
+                >
+                    {isSubmitting ? '登録中…' : '登録'}
+                </button>
+            </div>
+        </form>
+    )
+}

--- a/frontend/src/components/contents/form/addTagForm.tsx
+++ b/frontend/src/components/contents/form/addTagForm.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import axios from 'axios'
+
+interface Props {
+    apiEndpoint: string
+    onCancel: () => void
+}
+
+const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+export default function AddTagForm({ apiEndpoint, onCancel }: Props) {
+    const [tagName, setTagName] = useState('')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setIsSubmitting(true)
+        try {
+            await axios.post(
+                `${API_URL}/${apiEndpoint}`,
+                { tag_name: tagName },
+                { withCredentials: true }
+            )
+            setTagName('')
+            onCancel()
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-3 mt-2">
+            <div>
+                <label className="block text-xs text-gray-500 mb-1">タグ名</label>
+                <input
+                    type="text"
+                    value={tagName}
+                    onChange={(e) => setTagName(e.target.value)}
+                    required
+                    className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                />
+            </div>
+            <div className="flex gap-2 pt-1">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="flex-1 text-sm text-gray-500 border border-gray-300 rounded py-1 hover:bg-gray-50"
+                >
+                    キャンセル
+                </button>
+                <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="flex-1 text-sm text-white bg-indigo-500 rounded py-1 hover:bg-indigo-600 disabled:opacity-50"
+                >
+                    {isSubmitting ? '登録中…' : '登録'}
+                </button>
+            </div>
+        </form>
+    )
+}

--- a/frontend/src/components/header/ExpenditureHeader.tsx
+++ b/frontend/src/components/header/ExpenditureHeader.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react'
+import axios from 'axios'
+
+interface Props {
+    headerMessage: string
+    to: string
+    apiEndpoint: string
+}
+
+const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+export default function ExpenditureHeader({ headerMessage, apiEndpoint }: Props) {
+    const [isOpen, setIsOpen] = useState(false)
+    const [expenseName, setExpenseName] = useState('')
+    const [amount, setAmount] = useState('')
+    const [expenseAt, setExpenseAt] = useState('')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setIsSubmitting(true)
+        try {
+            await axios.post(
+                `${API_URL}/${apiEndpoint}`,
+                { expense_name: expenseName, amount: Number(amount), expense_at: expenseAt },
+                { withCredentials: true }
+            )
+            setExpenseName('')
+            setAmount('')
+            setExpenseAt('')
+            setIsOpen(false)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <div className="relative">
+            <button
+                onClick={() => setIsOpen(!isOpen)}
+                className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-indigo-600 transition-colors"
+            >
+                {headerMessage}
+                <span className="text-xs">{isOpen ? '▲' : '▼'}</span>
+            </button>
+
+            {isOpen && (
+                <div className="absolute left-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-100 p-4 z-50">
+                    <form onSubmit={handleSubmit} className="space-y-3">
+                        <div>
+                            <label className="block text-xs text-gray-500 mb-1">支出名</label>
+                            <input
+                                type="text"
+                                value={expenseName}
+                                onChange={(e) => setExpenseName(e.target.value)}
+                                required
+                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-xs text-gray-500 mb-1">金額（円）</label>
+                            <input
+                                type="number"
+                                value={amount}
+                                onChange={(e) => setAmount(e.target.value)}
+                                required
+                                min={0}
+                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-xs text-gray-500 mb-1">日付</label>
+                            <input
+                                type="date"
+                                value={expenseAt}
+                                onChange={(e) => setExpenseAt(e.target.value)}
+                                required
+                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                            />
+                        </div>
+                        <div className="flex gap-2 pt-1">
+                            <button
+                                type="button"
+                                onClick={() => setIsOpen(false)}
+                                className="flex-1 text-sm text-gray-500 border border-gray-300 rounded py-1 hover:bg-gray-50"
+                            >
+                                キャンセル
+                            </button>
+                            <button
+                                type="submit"
+                                disabled={isSubmitting}
+                                className="flex-1 text-sm text-white bg-indigo-500 rounded py-1 hover:bg-indigo-600 disabled:opacity-50"
+                            >
+                                {isSubmitting ? '登録中…' : '登録'}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/components/header/ExpenditureHeader.tsx
+++ b/frontend/src/components/header/ExpenditureHeader.tsx
@@ -3,13 +3,17 @@ import AddExpenditureForm from '../contents/form/addExpenditureForm'
 
 interface Props {
     headerMessage: string
-    to: string
     apiEndpoint: string
+    isOpen: boolean
+    setIsOpen: (isOpen: boolean) => void
 }
 
-export default function ExpenditureHeader({ headerMessage, apiEndpoint }: Props) {
-    const [isOpen, setIsOpen] = useState(false)
-
+export default function ExpenditureHeader({ 
+    headerMessage,
+    apiEndpoint,
+    isOpen,
+    setIsOpen
+}: Props) {
     return (
         <div className="relative">
             <button

--- a/frontend/src/components/header/ExpenditureHeader.tsx
+++ b/frontend/src/components/header/ExpenditureHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import axios from 'axios'
+import AddExpenditureForm from '../contents/form/addExpenditureForm'
 
 interface Props {
     headerMessage: string
@@ -7,32 +7,8 @@ interface Props {
     apiEndpoint: string
 }
 
-const API_URL = import.meta.env.VITE_API_URL ?? '/api'
-
 export default function ExpenditureHeader({ headerMessage, apiEndpoint }: Props) {
     const [isOpen, setIsOpen] = useState(false)
-    const [expenseName, setExpenseName] = useState('')
-    const [amount, setAmount] = useState('')
-    const [expenseAt, setExpenseAt] = useState('')
-    const [isSubmitting, setIsSubmitting] = useState(false)
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-        setIsSubmitting(true)
-        try {
-            await axios.post(
-                `${API_URL}/${apiEndpoint}`,
-                { expense_name: expenseName, amount: Number(amount), expense_at: expenseAt },
-                { withCredentials: true }
-            )
-            setExpenseName('')
-            setAmount('')
-            setExpenseAt('')
-            setIsOpen(false)
-        } finally {
-            setIsSubmitting(false)
-        }
-    }
 
     return (
         <div className="relative">
@@ -46,55 +22,10 @@ export default function ExpenditureHeader({ headerMessage, apiEndpoint }: Props)
 
             {isOpen && (
                 <div className="absolute left-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-100 p-4 z-50">
-                    <form onSubmit={handleSubmit} className="space-y-3">
-                        <div>
-                            <label className="block text-xs text-gray-500 mb-1">支出名</label>
-                            <input
-                                type="text"
-                                value={expenseName}
-                                onChange={(e) => setExpenseName(e.target.value)}
-                                required
-                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-xs text-gray-500 mb-1">金額（円）</label>
-                            <input
-                                type="number"
-                                value={amount}
-                                onChange={(e) => setAmount(e.target.value)}
-                                required
-                                min={0}
-                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-xs text-gray-500 mb-1">日付</label>
-                            <input
-                                type="date"
-                                value={expenseAt}
-                                onChange={(e) => setExpenseAt(e.target.value)}
-                                required
-                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
-                            />
-                        </div>
-                        <div className="flex gap-2 pt-1">
-                            <button
-                                type="button"
-                                onClick={() => setIsOpen(false)}
-                                className="flex-1 text-sm text-gray-500 border border-gray-300 rounded py-1 hover:bg-gray-50"
-                            >
-                                キャンセル
-                            </button>
-                            <button
-                                type="submit"
-                                disabled={isSubmitting}
-                                className="flex-1 text-sm text-white bg-indigo-500 rounded py-1 hover:bg-indigo-600 disabled:opacity-50"
-                            >
-                                {isSubmitting ? '登録中…' : '登録'}
-                            </button>
-                        </div>
-                    </form>
+                    <AddExpenditureForm
+                        apiEndpoint={apiEndpoint}
+                        onCancel={() => setIsOpen(false)}
+                    />
                 </div>
             )}
         </div>

--- a/frontend/src/components/header/MainPagaHeader.tsx
+++ b/frontend/src/components/header/MainPagaHeader.tsx
@@ -1,25 +1,30 @@
-import HeaderTag from './HeaderTag'
+import TagHeader from './TagHeader'
 import AppName from './AppName'
+import ExpenditureHeader  from './ExpenditureHeader'
 
 export default function AllPageHeader() {
     return (
         <div className="flex items-center w-full">
             <div className="flex gap-4 flex-wrap">
-                <HeaderTag
+                <ExpenditureHeader
                     headerMessage = '確定支出追加・削除'
                     to = "/login"
+                    apiEndpoint='must-expenditures'
                 />
-                <HeaderTag
+                <ExpenditureHeader
                     headerMessage = '支出追加・削除'
                     to = "/login"
+                    apiEndpoint='daily-expenditures'
                 />
-                <HeaderTag
+                <TagHeader
                     headerMessage = 'タグ追加・削除'
                     to = "/login"
+                    apiEndpoint='/api/daily-expenditure-tags'
                 />
-                <HeaderTag
+                <TagHeader
                     headerMessage = '必須出資タグ追加・削除'
                     to = "/login"
+                    apiEndpoint='must-expenditure-tags'
                 />
             </div>
             <div className="ml-auto shrink-0 pl-4">

--- a/frontend/src/components/header/MainPagaHeader.tsx
+++ b/frontend/src/components/header/MainPagaHeader.tsx
@@ -17,14 +17,14 @@ export default function AllPageHeader() {
                     apiEndpoint='daily-expenditures'
                 />
                 <TagHeader
-                    headerMessage = 'タグ追加・削除'
-                    to = "/login"
-                    apiEndpoint='/api/daily-expenditure-tags'
-                />
-                <TagHeader
                     headerMessage = '必須出資タグ追加・削除'
                     to = "/login"
                     apiEndpoint='must-expenditure-tags'
+                />
+                <TagHeader
+                    headerMessage = 'タグ追加・削除'
+                    to = "/login"
+                    apiEndpoint='daily-expenditure-tags'
                 />
             </div>
             <div className="ml-auto shrink-0 pl-4">

--- a/frontend/src/components/header/MainPagaHeader.tsx
+++ b/frontend/src/components/header/MainPagaHeader.tsx
@@ -1,30 +1,39 @@
+import { useState } from 'react'
 import TagHeader from './TagHeader'
 import AppName from './AppName'
-import ExpenditureHeader  from './ExpenditureHeader'
+import ExpenditureHeader from './ExpenditureHeader'
 
 export default function AllPageHeader() {
+    const [openForm, setOpenForm] = useState<string | null>(null)
+
+    const toggle = (key: string) => (val: boolean) => setOpenForm(val ? key : null)
+
     return (
         <div className="flex items-center w-full">
             <div className="flex gap-4 flex-wrap">
                 <ExpenditureHeader
-                    headerMessage = '確定支出追加・削除'
-                    to = "/login"
+                    headerMessage='確定支出追加・削除'
                     apiEndpoint='must-expenditures'
+                    isOpen={openForm === 'must-expenditures'}
+                    setIsOpen={toggle('must-expenditures')}
                 />
                 <ExpenditureHeader
-                    headerMessage = '支出追加・削除'
-                    to = "/login"
+                    headerMessage='支出追加・削除'
                     apiEndpoint='daily-expenditures'
+                    isOpen={openForm === 'daily-expenditures'}
+                    setIsOpen={toggle('daily-expenditures')}
                 />
                 <TagHeader
-                    headerMessage = '必須出資タグ追加・削除'
-                    to = "/login"
+                    headerMessage='必須出資タグ追加・削除'
                     apiEndpoint='must-expenditure-tags'
+                    isOpen={openForm === 'must-expenditure-tags'}
+                    setIsOpen={toggle('must-expenditure-tags')}
                 />
                 <TagHeader
-                    headerMessage = 'タグ追加・削除'
-                    to = "/login"
+                    headerMessage='タグ追加・削除'
                     apiEndpoint='daily-expenditure-tags'
+                    isOpen={openForm === 'daily-expenditure-tags'}
+                    setIsOpen={toggle('daily-expenditure-tags')}
                 />
             </div>
             <div className="ml-auto shrink-0 pl-4">

--- a/frontend/src/components/header/TagHeader.tsx
+++ b/frontend/src/components/header/TagHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import axios from 'axios'
+import AddTagForm from '../contents/form/addTagForm'
 
 interface Props {
     headerMessage: string
@@ -7,28 +7,8 @@ interface Props {
     apiEndpoint: string
 }
 
-const API_URL = import.meta.env.VITE_API_URL ?? '/api'
-
 export default function TagHeader({ headerMessage, apiEndpoint }: Props) {
     const [isOpen, setIsOpen] = useState(false)
-    const [tagName, setTagName] = useState('')
-    const [isSubmitting, setIsSubmitting] = useState(false)
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-        setIsSubmitting(true)
-        try {
-            await axios.post(
-                `${API_URL}/${apiEndpoint}`,
-                { tag_name: tagName },
-                { withCredentials: true }
-            )
-            setTagName('')
-            setIsOpen(false)
-        } finally {
-            setIsSubmitting(false)
-        }
-    }
 
     return (
         <div className="relative">
@@ -41,35 +21,11 @@ export default function TagHeader({ headerMessage, apiEndpoint }: Props) {
             </button>
 
             {isOpen && (
-                <div className="absolute left-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-100 p-4 z-50">
-                    <form onSubmit={handleSubmit} className="space-y-3">
-                        <div>
-                            <label className="block text-xs text-gray-500 mb-1">タグ名</label>
-                            <input
-                                type="text"
-                                value={tagName}
-                                onChange={(e) => setTagName(e.target.value)}
-                                required
-                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
-                            />
-                        </div>
-                        <div className="flex gap-2 pt-1">
-                            <button
-                                type="button"
-                                onClick={() => setIsOpen(false)}
-                                className="flex-1 text-sm text-gray-500 border border-gray-300 rounded py-1 hover:bg-gray-50"
-                            >
-                                キャンセル
-                            </button>
-                            <button
-                                type="submit"
-                                disabled={isSubmitting}
-                                className="flex-1 text-sm text-white bg-indigo-500 rounded py-1 hover:bg-indigo-600 disabled:opacity-50"
-                            >
-                                {isSubmitting ? '登録中…' : '登録'}
-                            </button>
-                        </div>
-                    </form>
+                <div className="absolute left-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-100 p-4 z-50">
+                    <AddTagForm
+                        apiEndpoint={apiEndpoint}
+                        onCancel={() => setIsOpen(false)}
+                    />
                 </div>
             )}
         </div>

--- a/frontend/src/components/header/TagHeader.tsx
+++ b/frontend/src/components/header/TagHeader.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import axios from 'axios'
+
+interface Props {
+    headerMessage: string
+    to: string
+    apiEndpoint: string
+}
+
+const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+export default function TagHeader({ headerMessage, apiEndpoint }: Props) {
+    const [isOpen, setIsOpen] = useState(false)
+    const [tagName, setTagName] = useState('')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setIsSubmitting(true)
+        try {
+            await axios.post(
+                `${API_URL}/${apiEndpoint}`,
+                { tag_name: tagName },
+                { withCredentials: true }
+            )
+            setTagName('')
+            setIsOpen(false)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <div className="relative">
+            <button
+                onClick={() => setIsOpen(!isOpen)}
+                className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-indigo-600 transition-colors"
+            >
+                {headerMessage}
+                <span className="text-xs">{isOpen ? '▲' : '▼'}</span>
+            </button>
+
+            {isOpen && (
+                <div className="absolute left-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-100 p-4 z-50">
+                    <form onSubmit={handleSubmit} className="space-y-3">
+                        <div>
+                            <label className="block text-xs text-gray-500 mb-1">タグ名</label>
+                            <input
+                                type="text"
+                                value={tagName}
+                                onChange={(e) => setTagName(e.target.value)}
+                                required
+                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                            />
+                        </div>
+                        <div className="flex gap-2 pt-1">
+                            <button
+                                type="button"
+                                onClick={() => setIsOpen(false)}
+                                className="flex-1 text-sm text-gray-500 border border-gray-300 rounded py-1 hover:bg-gray-50"
+                            >
+                                キャンセル
+                            </button>
+                            <button
+                                type="submit"
+                                disabled={isSubmitting}
+                                className="flex-1 text-sm text-white bg-indigo-500 rounded py-1 hover:bg-indigo-600 disabled:opacity-50"
+                            >
+                                {isSubmitting ? '登録中…' : '登録'}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/components/header/TagHeader.tsx
+++ b/frontend/src/components/header/TagHeader.tsx
@@ -3,13 +3,17 @@ import AddTagForm from '../contents/form/addTagForm'
 
 interface Props {
     headerMessage: string
-    to: string
     apiEndpoint: string
+    isOpen: boolean
+    setIsOpen: (isOpen: boolean) => void
 }
 
-export default function TagHeader({ headerMessage, apiEndpoint }: Props) {
-    const [isOpen, setIsOpen] = useState(false)
-
+export default function TagHeader({
+    headerMessage,
+    apiEndpoint,
+    isOpen,
+    setIsOpen
+}: Props) {
     return (
         <div className="relative">
             <button


### PR DESCRIPTION
アプリのヘッダー部分を作成しました
主にタグの登録、金額の登録の二つを行うことができる場所となっています

<img width="835" height="422" alt="スクリーンショット 2026-04-19 15 33 43" src="https://github.com/user-attachments/assets/07f11663-37a4-4466-9c8c-4392a188a471" />
<img width="885" height="435" alt="スクリーンショット 2026-04-19 15 33 47" src="https://github.com/user-attachments/assets/4f4443e9-92ff-4b48-b9e1-737697865d38" />

このような形で各種フォームを開いている状態だと別フォームは閉じるようにしています
またrelativeにしていることで画面上に重なるように表示できるようにしています

仮にデータの更新があった場合は即座に画面に反映されるようになっています
