### PR TITLE
#28 | 日々の出費を記録する部分を追加

### DIFF
--- a/backend/app/Http/Controllers/Api/DailyExpenditureDailyExpenditureTagRelationController.php
+++ b/backend/app/Http/Controllers/Api/DailyExpenditureDailyExpenditureTagRelationController.php
@@ -37,6 +37,13 @@ class DailyExpenditureDailyExpenditureTagRelationController extends Controller
         return response()->json($result, 201);
     }
 
+    public function expendituresWithTag(Request $request): JsonResponse
+    {
+        return response()->json(
+            $this->service->getExpendituresWithTag($request->user()->id)
+        );
+    }
+
     public function amountByTag(Request $request): JsonResponse
     {
         return response()->json(

--- a/backend/app/Models/DailyExpenditure.php
+++ b/backend/app/Models/DailyExpenditure.php
@@ -5,6 +5,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+// tableカラム
+// id
+// user_id
+// expense_name
+// expense_at
+// created_at
+// updated_at
+
 class DailyExpenditure extends Model
 {
     use HasFactory;

--- a/backend/app/Services/DailyExpenditureDailyExpenditureTagRelationService.php
+++ b/backend/app/Services/DailyExpenditureDailyExpenditureTagRelationService.php
@@ -33,6 +33,22 @@ class DailyExpenditureDailyExpenditureTagRelationService
         DailyExpenditureDailyExpenditureTagRelation::whereKey($id)->delete();
     }
 
+    public function getExpendituresWithTag(int $userId): Collection
+    {
+        return DailyExpenditureDailyExpenditureTagRelation::query()
+            ->where('daily_expenditure_daily_expenditure_tag_relations.user_id', $userId)
+            ->join('daily_expenditure_tags', 'daily_expenditure_daily_expenditure_tag_relations.daily_expenditure_tag_id', '=', 'daily_expenditure_tags.id')
+            ->join('daily_expenditures', 'daily_expenditure_daily_expenditure_tag_relations.daily_expenditure_id', '=', 'daily_expenditures.id')
+            ->orderBy('daily_expenditures.expense_at', 'desc')
+            ->select([
+                'daily_expenditures.expense_name',
+                'daily_expenditures.amount',
+                'daily_expenditures.expense_at',
+                'daily_expenditure_tags.tag_name',
+            ])
+            ->get();
+    }
+
     public function getAmountGroupByTag(int $userId): Collection
     {
         return DailyExpenditureDailyExpenditureTagRelation::query()

--- a/frontend/src/components/contents/expenditureGraph/textGraph.tsx
+++ b/frontend/src/components/contents/expenditureGraph/textGraph.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+interface DailyExpenditureWithTag {
+    expense_name: string
+    amount: number
+    expense_at: string
+    tag_name: string
+}
+
+const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+export default function TextGraph() {
+    const [list, setList] = useState<DailyExpenditureWithTag[]>([])
+
+    const fetchData = () => {
+        axios.get<DailyExpenditureWithTag[]>(
+            `${API_URL}/daily-expenditure-daily-expenditure-tag-relations/expenditures-with-tag`,
+            { withCredentials: true }
+        ).then((res) => setList(res.data))
+    }
+
+    useEffect(() => {
+        fetchData()
+        window.addEventListener('expenditure-registered', fetchData)
+        return () => window.removeEventListener('expenditure-registered', fetchData)
+    }, [])
+
+    return (
+        <>
+            <div className="space-y-3 w-250 max-h-64 overflow-y-scroll border py-2">
+                <div className='w-200 flex justify-between items-center border-b border-gray-100 py-2 text-sm'>
+                    <div className="flex items-center gap-2 w-2/5 bg-blue-500">
+                        <span className="text-xs text-white w-1/2 bg-indigo-400 rounded px-2 py-0.5 text-center">タグ名</span>
+                        <span className="text-gray-800 w-1/2 text-center">支払い名</span>
+                    </div>
+                    <div className="flex items-center gap-4 text-gray-500 w-3/5 bg-red-500">
+                        <span className='text-center w-1/2'>支払日</span>
+                        <span className="font-medium text-gray-800 text-center w-1/2">金額</span>
+                    </div>
+                </div>
+                <hr></hr>
+                {list.map((item, index) => (
+                    <div key={index} className="flex justify-between items-center border-b border-gray-100 py-2 text-sm">
+                        <div className="flex items-center gap-2 w-2/5 bg-blue-500">
+                            <span className="text-xs text-white w-1/2 bg-indigo-400 rounded px-2 py-0.5 text-center">{item.tag_name}</span>
+                            <span className="text-gray-800 w-1/2 text-center">{item.expense_name}</span>
+                        </div>
+                        <div className="flex items-center gap-4 text-gray-500 w-3/5 bg-red-500">
+                            <span className='text-center w-1/2'>{item.expense_at.slice(0, 10)}</span>
+                            <span className="font-medium text-gray-800 text-center w-1/2">{item.amount.toLocaleString()}円</span>
+                        </div>
+                    </div>
+                ))}
+                {list.length === 0 && (
+                    <p className="text-gray-400 text-sm">データがありません</p>
+                )}
+            </div>
+        </>
+    )
+}

--- a/frontend/src/components/contents/mustExpenditure/textGraph.tsx
+++ b/frontend/src/components/contents/mustExpenditure/textGraph.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+interface DailyExpenditureWithTag {
+    expense_name: string
+    amount: number
+    expense_at: string
+    tag_name: string
+}
+
+const API_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+export default function TextGraph() {
+    const [list, setList] = useState<DailyExpenditureWithTag[]>([])
+
+    const fetchData = () => {
+        axios.get<DailyExpenditureWithTag[]>(
+            `${API_URL}/daily-expenditure-daily-expenditure-tag-relations/expenditures-with-tag`,
+            { withCredentials: true }
+        ).then((res) => setList(res.data))
+    }
+
+    useEffect(() => {
+        fetchData()
+        window.addEventListener('expenditure-registered', fetchData)
+        return () => window.removeEventListener('expenditure-registered', fetchData)
+    }, [])
+
+    return (
+        <>
+            <div className="space-y-3 w-250 max-h-64 overflow-y-scroll border py-2">
+                <div className='w-200 flex justify-between items-center border-b border-gray-100 py-2 text-sm'>
+                    <div className="flex items-center gap-2 w-2/5 bg-blue-500">
+                        <span className="text-xs text-white w-1/2 bg-indigo-400 rounded px-2 py-0.5 text-center">タグ名</span>
+                        <span className="text-gray-800 w-1/2 text-center">支払い名</span>
+                    </div>
+                    <div className="flex items-center gap-4 text-gray-500 w-3/5 bg-red-500">
+                        <span className='text-center w-1/2'>支払日</span>
+                        <span className="font-medium text-gray-800 text-center w-1/2">金額</span>
+                    </div>
+                </div>
+                <hr></hr>
+                {list.map((item, index) => (
+                    <div key={index} className="flex justify-between items-center border-b border-gray-100 py-2 text-sm">
+                        <div className="flex items-center gap-2 w-2/5 bg-blue-500">
+                            <span className="text-xs text-white w-1/2 bg-indigo-400 rounded px-2 py-0.5 text-center">{item.tag_name}</span>
+                            <span className="text-gray-800 w-1/2 text-center">{item.expense_name}</span>
+                        </div>
+                        <div className="flex items-center gap-4 text-gray-500 w-3/5 bg-red-500">
+                            <span className='text-center w-1/2'>{item.expense_at.slice(0, 10)}</span>
+                            <span className="font-medium text-gray-800 text-center w-1/2">{item.amount.toLocaleString()}円</span>
+                        </div>
+                    </div>
+                ))}
+                {list.length === 0 && (
+                    <p className="text-gray-400 text-sm">データがありません</p>
+                )}
+            </div>
+        </>
+    )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import AllExpenditure from '../components/contents/allExpenditure'
+import DailyExpenditureTextGraph from '../components/contents/mustExpenditure/textGraph.tsx'
 
 interface Summary {
   income: number
@@ -48,6 +49,9 @@ export default function Dashboard() {
           <p className="text-sm text-gray-500 mb-1">残高</p>
           <p className="text-2xl font-bold text-indigo-600">{fmt(summary.balance)}</p>
         </div>
+      </div>
+      <div className='h-200 w-1/2 space-y-1 space-x-3 border m-5'>
+        <DailyExpenditureTextGraph/>
       </div>
     </div>
   )

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import AllExpenditure from '../components/contents/allExpenditure'
-import DailyExpenditureTextGraph from '../components/contents/mustExpenditure/textGraph.tsx'
+import DailyExpenditureTextGraph from '../components/contents/expenditureGraph/textGraph.tsx'
 
 interface Summary {
   income: number


### PR DESCRIPTION
<img width="876" height="677" alt="スクリーンショット 2026-04-22 22 24 09" src="https://github.com/user-attachments/assets/1f705659-59c2-4a17-94a7-056111449ce5" />

<img width="493" height="300" alt="スクリーンショット 2026-04-22 22 21 57" src="https://github.com/user-attachments/assets/ae196449-8ce3-4f08-8693-19c195d4cf00" />

デザイン等は後回しにして、一旦日々の出費を画面上に表示することができる箇所を追記しました
これらは出費を追加した時点で反映されるようになっており、また一定データ以上が存在している場合はスクロール表示に切り替わるようになっています

スクロールを常時表示したかったものの、scroll-yを指定してもmacOS側の挙動制御によりスクロール自体は常に表示されない状態となっており、対応策に関してはのちに講じ�ようと思います